### PR TITLE
Replace broken lists.case.edu mail list link

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@ intro:
             Checkout <a
                 href="http://hacsoc.org/talks">some of our past talks</a>
             (note: infrequently updated). For an up-to-date list, see the <a
-                href="https://lists.case.edu/wws/arc/cwru-hackers">archives</a>
-            of our <a href="https://lists.case.edu/wws/info/cwru-hackers">
+                href="https://groups.google.com/a/case.edu/forum/#!forum/cwru-hackers">archives</a>
+            of our <a href="https://groups.google.com/a/case.edu/forum/#!members/cwru-hackers">
                 mailing list</a> which you should subscribe to. You can and
             should give a talk at hacker society. <a
                 href="http://goo.gl/forms/Zk66w76kA1">Sign up now</a>. You
@@ -78,7 +78,7 @@ intro:
     </div>
     <div class="col-lg-8 text-justify">
         <p>
-            To get started, sign up for our <a href="https://lists.case.edu/wws/info/cwru-hackers"
+            To get started, sign up for our <a href="https://groups.google.com/a/case.edu/forum/#!members/cwru-hackers"
                 style="font">mailing list</a>. We send out an newsletter/email
             thing at the beginning of the week with all the details of that
             week's events. Join the list because that's where it's happening!


### PR DESCRIPTION
Update the mailing list subscription link and the email archives link with the new google groups link. The lists.case.edu ones display an error and there's no obvious join button or redirection to the google groups page.